### PR TITLE
run_number error

### DIFF
--- a/config/supervised_hp.py
+++ b/config/supervised_hp.py
@@ -9,7 +9,7 @@ config = {}
 config['experiment'] = 'SupervisedLearningFL'
 config['model_fn'] = 'DenseSupervisedModel'
 config['sample_client_data'] = False      # must set to False when running real experiments
-config['run_number'] = 0                  # always initialize as 0, unless starting from a certain run
+config['curr_run_number'] = 0                  # always initialize as 0, unless starting from a certain run
 
 # data loading
 config['shuffle_buffer'] = 100


### PR DESCRIPTION
Should this be curr_run_number and not run_number? Was getting an error when running this config 

Traceback (most recent call last):
  File "main.py", line 36, in <module>
    for i in range(ph['curr_run_number'], len(hparam_sets)):
  File "/home/geoffreyli/semisupervisedFL/parameter_handler.py", line 79, in __getitem__
    raise KeyError('No saved parameter named `{}`'.format(key))
KeyError: 'No saved parameter named `curr_run_number`'